### PR TITLE
Language bugg

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 * linguist-vendored
-*.ipynb linguist-vendored=false
+*.jl linguist-vendored=false


### PR DESCRIPTION
Solution to the problem of showing Jupyter notebooks as the main language in this repo. 

Reference for the solution: 
https://stackoverflow.com/questions/34713765/github-changes-repository-to-wrong-language
