### PR TITLE
Agregar función de inflación de evaluación a SimConfig

### DIFF
--- a/scripts/test_SimConfig.jl
+++ b/scripts/test_SimConfig.jl
@@ -47,9 +47,9 @@ configC = CrossEvalConfig(percEq, resamplefn, trendfn, paramfn, 1000, Date(2012,
 
 # Algunas utilidades relacionadas con los objetos AbstractConfig
 # Creación de nombres para almacenar archivos (función savename de DrWatson)
-savename(configA, connector=" | ", equals=" = ")
-savename(configB, connector=" | ", equals=" = ")
-savename(configC, connector=" | ", equals=" = ")
+savename(configA)
+savename(configB)
+savename(configC)
 
 # Conversión de AbstractConfig a Diccionario (función de DrWatson)
 dic_a = struct2dict(configA)
@@ -93,9 +93,9 @@ dict_pruebaC = Dict(
 # se utiliza dentro de la función run_batch, previo a darle la información a la información
 # a la función makesim.
 
-configD_a = dict_config.(dict_prueba)
-configC_a = dict_config.(dict_pruebaC)
-configE = dict_config.(dict_pruebaB)
+configD_a = dict_config(dict_prueba)
+configC_a = dict_config(dict_pruebaC)
+configE = dict_config(dict_pruebaB)
 
 
 ## FUNCIONES DE EVALUACIÓN
@@ -183,8 +183,10 @@ savepath_pw = datadir("results", "PercWeigthed-scramble")
 run_batch(gtdata_eval, dict_percW, savepath_pw)
 
 # 4. Revisión de resultados, usando collect_results
-df_pw = collect_results(savepath_pw)
+df_pw = collect_results(savepath_pw);
 
+using DataFrames
+select(df_pw, :measure, :mse)
 # revisión gráfica
 scatter(60:80, df_pw.mse, 
     ylims = (0, 15),

--- a/scripts/test_SimConfig.jl
+++ b/scripts/test_SimConfig.jl
@@ -165,12 +165,14 @@ scatter(60:80, df.mse,
 resamplefn = ResampleSBB(36)
 resamplefn2 = ResampleScrambleVarMonths()
 trendfn = TrendRandomWalk()
+paramfn = InflationTotalRebaseCPI(36, 2)
 # la función de inflación, la instanciamos dentro del diccionario.
 
 dict_percW = Dict(
     :inflfn => InflationPercentileWeighted.(50:80), 
     :resamplefn => [resamplefn2],
     :trendfn => trendfn,
+    :paramfn => paramfn,
     :nsim => 100) |> dict_list
 
 
@@ -192,10 +194,12 @@ scatter(60:80, df_pw.mse,
 
 
 ##
-# ## Ejemplo de evaluación con búsqueda de parámetros 
+# ## Ejemplo de evaluación con parámetros de evaluación 2019 
+# Datos a diciembre 2019
+gtdata_eval19 = gtdata[Date(2019, 12)]
 
-config = SimConfig(InflationPercentileEq(69), ResampleSBB(36), TrendRandomWalk(), 10_000)
+# Configuración para percentil equiponderado 69, Metodo de selección por meses, Caminata aleatoria e Inflación de evaluación con hasta 2 cambios de base.
+config = SimConfig(InflationPercentileEq(69), ResampleScrambleVarMonths(), TrendRandomWalk(), InflationTotalRebaseCPI(36, 2), 10_000)
 
-results = evalsim(gtdata_eval, config)
-
-## Terminar ejemplo con NLopt u Optim...
+results, tray_infl = evalsim(gtdata_eval19, config)
+results

--- a/scripts/test_SimConfig.jl
+++ b/scripts/test_SimConfig.jl
@@ -30,6 +30,7 @@ fxEx = InflationFixedExclusionCPI(excOpt00, excOpt10)
 # Funciones de remuestreo y tendencia
 resamplefn = ResampleSBB(36)
 trendfn = TrendRandomWalk()
+paramfn = InflationTotalRebaseCPI(60)
 
 # Otros parametros (para CrossEvalConfig)
 ff = Date(2020, 12)
@@ -38,10 +39,10 @@ sz = 24
 
 ## Creación de configuraciones de prueba usando objetos AbstractConfig.
 
-configA = SimConfig(totalfn, resamplefn, trendfn, 1000)
-configB = SimConfig(fxEx, resamplefn, trendfn, 1000)
-configC = SimConfig(percEq, resamplefn, trendfn, 1000)
-configC = CrossEvalConfig(percEq, resamplefn, trendfn, 1000, Date(2012, 12), 24)
+configA = SimConfig(totalfn, resamplefn, trendfn, paramfn, 1000)
+configB = SimConfig(fxEx, resamplefn, trendfn, paramfn, 1000)
+configC = SimConfig(percEq, resamplefn, trendfn, paramfn, 1000)
+configC = CrossEvalConfig(percEq, resamplefn, trendfn, paramfn, 1000, Date(2012, 12), 24)
 
 
 # Algunas utilidades relacionadas con los objetos AbstractConfig
@@ -65,6 +66,7 @@ dict_prueba = Dict(
     :inflfn => InflationPercentileEq.(60:80), 
     :resamplefn => resamplefn, 
     :trendfn => trendfn,
+    :paramfn => paramfn,
     :nsim => 100) |> dict_list
 
 # Diccionario de prueba 2: utilizando dict_list (DrWatson), 
@@ -73,6 +75,7 @@ dict_pruebaB = Dict(
     :inflfn => totalfn, 
     :resamplefn => resamplefn, 
     :trendfn => trendfn,
+    :paramfn => paramfn,
     :nsim => 10_000) |> dict_list
 
 # Diccionario de prueba 3: utilizando dict_list (DrWatson), 
@@ -82,6 +85,7 @@ dict_pruebaC = Dict(
         :inflfn => fxEx, 
         :resamplefn => resamplefn, 
         :trendfn => trendfn,
+        :paramfn => paramfn,
         :nsim => 1000) |> dict_list
 
 

--- a/src/InflationEvalTools/src/config/SimConfig.jl
+++ b/src/InflationEvalTools/src/config/SimConfig.jl
@@ -51,7 +51,7 @@ Base.@kwdef struct SimConfig{F, R, T} <:AbstractConfig{F, R, T}
     # Función de Tendencia
     trendfn::T
     # Función de inflación paramétrica 
-    paramfn::Any
+    paramfn
     # Cantidad de Simulaciones
     nsim::Int  
 end
@@ -104,7 +104,7 @@ Base.@kwdef struct CrossEvalConfig{F, R, T} <:AbstractConfig{F, R, T}
     # Función de Tendencia
     trendfn::T
     # # Función de inflación paramétrica 
-    paramfn::Any
+    paramfn
     # Cantidad de simulaciones
     nsim::Int
     # Último mes de set de "entrenamiento"
@@ -117,18 +117,19 @@ end
 Base.string(inflfn::InflationFunction) = measure_tag(inflfn)
 Base.string(resamplefn::ResampleFunction) = method_tag(resamplefn)
 Base.string(trendfn::TrendFunction) = method_tag(trendfn)
+# Base.string(paramfn) = measure_tag(paramfn)
 
 # Método para mostrar información de la configuración en el REPL
 function Base.show(io::IO, config::AbstractConfig)
     println(io, typeof(config))
-    println(io, "|─> ", "Función de inflación     : ", measure_tag(config.inflfn))
-    println(io, "|─> ", "Función de remuestreo    : ", method_tag(config.resamplefn))
-    println(io, "|─> ", "Función de tendencia     : ", method_tag(config.trendfn))
-    println(io, "|─> ", "Inflación paramétrica    : ", nameof(config.paramfn))
-    println(io, "|─> ", "Simulaciones             : ", config.nsim)
+    println(io, "|─> ", "Función de inflación               : ", measure_tag(config.inflfn))
+    println(io, "|─> ", "Función de remuestreo              : ", method_tag(config.resamplefn))
+    println(io, "|─> ", "Función de tendencia               : ", method_tag(config.trendfn))
+    println(io, "|─> ", "Método de Inflación paramétrica    : ", measure_tag(config.paramfn))
+    println(io, "|─> ", "Simulaciones                       : ", config.nsim)
     if config isa CrossEvalConfig 
-        println(io, "|─> ", "Fin set de entrenamiento : ", config.train_date)
-        println(io, "|─> ", "Meses de evaluación      : ", config.eval_size)
+        println(io, "|─> ", "Fin set de entrenamiento           : ", config.train_date)
+        println(io, "|─> ", "Meses de evaluación                : ", config.eval_size)
     end
 end
 

--- a/src/InflationEvalTools/src/config/SimConfig.jl
+++ b/src/InflationEvalTools/src/config/SimConfig.jl
@@ -8,7 +8,7 @@ general, una función de inflación [`InflationFunction`](@ref), una función de
 remuestreo [`ResampleFunction`](@ref) y una función de Tendencia
 [`TrendFunction`](@ref). Contiene el esquema general de la simulación.
 """
-abstract type AbstractConfig{F <: InflationFunction, R <:ResampleFunction, T <:TrendFunction, P<:InflationParameter} end
+abstract type AbstractConfig{F <: InflationFunction, R <:ResampleFunction, T <:TrendFunction} end
 
 """
     SimConfig{F, R, T} <:AbstractConfig{F, R, T}
@@ -45,6 +45,8 @@ Base.@kwdef struct SimConfig{F, R, T} <:AbstractConfig{F, R, T}
     resamplefn::R
     # Función de Tendencia
     trendfn::T
+    # Función de inflación paramétrica 
+    paramfn::InflationParameter
     # Cantidad de Simulaciones
     nsim::Int  
 end
@@ -92,6 +94,8 @@ Base.@kwdef struct CrossEvalConfig{F, R, T} <:AbstractConfig{F, R, T}
     resamplefn::R
     # Función de Tendencia
     trendfn::T
+    # Función de inflación paramétrica 
+    paramfn::InflationParameter
     # Cantidad de simulaciones
     nsim::Int
     # Último mes de set de "entrenamiento"
@@ -104,14 +108,16 @@ end
 Base.string(inflfn::InflationFunction) = measure_tag(inflfn)
 Base.string(resamplefn::ResampleFunction) = method_tag(resamplefn)
 Base.string(trendfn::TrendFunction) = method_tag(trendfn)
+Base.string(paramfn::InflationParameter) = method_tag(paramfn)
 
 # Método para mostrar información de la configuración en el REPL
 function Base.show(io::IO, config::AbstractConfig)
     println(io, typeof(config))
-    println(io, "|─> ", "Función de inflación : ", measure_tag(config.inflfn))
-    println(io, "|─> ", "Función de remuestreo: ", method_tag(config.resamplefn))
-    println(io, "|─> ", "Función de tendencia : ", method_tag(config.trendfn))
-    println(io, "|─> ", "Simulaciones         : ", config.nsim)
+    println(io, "|─> ", "Función de inflación  : ", measure_tag(config.inflfn))
+    println(io, "|─> ", "Función de remuestreo : ", method_tag(config.resamplefn))
+    println(io, "|─> ", "Función de tendencia  : ", method_tag(config.trendfn))
+    println(io, "|─> ", "Inflación paramétrica : ", method_tag(config.paramfn))
+    println(io, "|─> ", "Simulaciones          : ", config.nsim)
     if config isa CrossEvalConfig 
         println(io, "|─> ", "Fin set de entrenamiento: ", config.train_date)
         println(io, "|─> ", "Meses de evaluación     : ", config.eval_size)

--- a/src/InflationEvalTools/src/config/SimConfig.jl
+++ b/src/InflationEvalTools/src/config/SimConfig.jl
@@ -117,26 +117,37 @@ end
 Base.string(inflfn::InflationFunction) = measure_tag(inflfn)
 Base.string(resamplefn::ResampleFunction) = method_tag(resamplefn)
 Base.string(trendfn::TrendFunction) = method_tag(trendfn)
-# Base.string(paramfn) = measure_tag(paramfn)
 
 # Método para mostrar información de la configuración en el REPL
 function Base.show(io::IO, config::AbstractConfig)
     println(io, typeof(config))
-    println(io, "|─> ", "Función de inflación               : ", measure_tag(config.inflfn))
-    println(io, "|─> ", "Función de remuestreo              : ", method_tag(config.resamplefn))
-    println(io, "|─> ", "Función de tendencia               : ", method_tag(config.trendfn))
-    println(io, "|─> ", "Método de Inflación paramétrica    : ", measure_tag(config.paramfn))
-    println(io, "|─> ", "Simulaciones                       : ", config.nsim)
+    println(io, "|─> ", "Función de inflación            : ", measure_name(config.inflfn))
+    println(io, "|─> ", "Función de remuestreo           : ", method_name(config.resamplefn))
+    println(io, "|─> ", "Función de tendencia            : ", method_name(config.trendfn))
+    println(io, "|─> ", "Método de inflación paramétrica : ", measure_name(config.paramfn))
+    println(io, "|─> ", "Número de simulaciones          : ", config.nsim)
     if config isa CrossEvalConfig 
-        println(io, "|─> ", "Fin set de entrenamiento           : ", config.train_date)
-        println(io, "|─> ", "Meses de evaluación                : ", config.eval_size)
+        println(io, "|─> ", "Fin set de entrenamiento        : ", config.train_date)
+        println(io, "|─> ", "Meses de evaluación             : ", config.eval_size)
     end
 end
 
 
 # Extensión de tipos permitidos para simulación en DrWatson
 DrWatson.default_allowed(::AbstractConfig) = (String, Symbol, TimeType, Function, Real) 
-DrWatson.default_prefix(::AbstractConfig) = "HEMI"
+DrWatson.default_prefix(::SimConfig) = "HEMI-SimConfig"
+DrWatson.default_prefix(::CrossEvalConfig) = "HEMI-CrossEvalConfig"
+
+# Definición de formato para guardado de archivos relacionados con la configuración
+DEFAULT_CONNECTOR = ", "
+DEFAULT_EQUALS = "="
+
+DrWatson.savename(conf::SimConfig, suffix::String = "jld2") = 
+    savename(conf, suffix; connector=DEFAULT_CONNECTOR, equals=DEFAULT_EQUALS)
+
+DrWatson.savename(conf::CrossEvalConfig, suffix::String = "jld2") = 
+    savename(conf, suffix; connector=DEFAULT_CONNECTOR, equals=DEFAULT_EQUALS)
+
 
 ## método para convertir de AbstractConfig a Diccionario 
 # Esto lo hace la función struct2dict() de DrWatson

--- a/src/InflationEvalTools/src/config/SimConfig.jl
+++ b/src/InflationEvalTools/src/config/SimConfig.jl
@@ -16,12 +16,13 @@ abstract type AbstractConfig{F <: InflationFunction, R <:ResampleFunction, T <:T
 Tipo concreto que contiene una configuración base para generar simulaciones
 utilizando todos los datos como set de entrenamiento. Recibe una función de
 inflación [`InflationFunction`](@ref), una función de remuestreo
-[`ResampleFunction`](@ref), una función de Tendencia [`TrendFunction`](@ref), y
-la cantidad de simulaciones deseadas [`nsim`].
+[`ResampleFunction`](@ref), una función de Tendencia [`TrendFunction`](@ref), 
+una función de inflación de evaluación [`paramfn`] y la cantidad de simulaciones 
+deseadas [`nsim`].
 
 ## Ejemplo
-Considerando las siguientes instancias de funciones de inflación, remuestreo y
-tendencia:
+Considerando las siguientes instancias de funciones de inflación, remuestreo,
+tendencia e inflación de evaluación:
 
 ```julia
 percEq = InflationPercentileEq(80)
@@ -34,9 +35,12 @@ Generamos una configuración del tipo `SimConfig` con 1000 simulaciones:
 
 ```julia-repl 
 julia> config = SimConfig(percEq, resamplefn, trendfn, paramfn, 1000)
-|─> Función de inflación : PercEq-80.0
-|─> Función de remuestreo: ResampleSBB-36
-|─> Función de tendencia : TrendRandomWalk
+|─> Función de inflación     : PercEq-80.0
+|─> Función de remuestreo    : ResampleSBB-36
+|─> Función de tendencia     : TrendRandomWalk
+|─> Inflación paramétrica    : InflationTotalRebaseCPI
+|─> Simulaciones             : 1000
+
 ```
 """
 Base.@kwdef struct SimConfig{F, R, T} <:AbstractConfig{F, R, T}
@@ -67,7 +71,8 @@ entrenamiento [`train_date`] y el tamaño del período de evaluación en meses
 
 ## Ejemplo
 
-Considerando las mismas funciones de inflación, remuestreo y tendencia: 
+Considerando las mismas funciones de inflación, remuestreo, tendencia e
+inflación de evaluación: 
 
 ```julia 
 percEq = InflationPercentileEq(80)
@@ -76,17 +81,19 @@ trendfn = TrendRandomWalk()
 paramfn = InflationTotalRebaseCPI(60)
 ```
 
-Generamos una configuración del tipo SimConfig con 1000 simulaciones y
+Generamos una configuración del tipo CrossEvalConfig con 1000 simulaciones y
 utilizando el fin de set de entrenamiento hasta diciembre de 2012 y 24 meses de
 evaluación.
 
 ```julia-repl 
 julia> config = CrossEvalConfig(percEq, resamplefn, trendfn, paramfn, 1000, Date(2012, 12), 24)
-|─> Función de inflación : PercEq-80.0
-|─> Función de remuestreo: ResampleSBB-36
-|─> Función de tendencia : TrendRandomWalk
-|─> Fin set de entrenamiento: 2012-12-01
-|─> Meses de evaluación     : 24
+|─> Función de inflación     : PercEq-80.0
+|─> Función de remuestreo    : ResampleSBB-36
+|─> Función de tendencia     : TrendRandomWalk
+|─> Inflación paramétrica    : InflationTotalRebaseCPI
+|─> Simulaciones             : 1000
+|─> Fin set de entrenamiento : 2012-12-01
+|─> Meses de evaluación      : 24
 ```
 """
 Base.@kwdef struct CrossEvalConfig{F, R, T} <:AbstractConfig{F, R, T}
@@ -110,8 +117,6 @@ end
 Base.string(inflfn::InflationFunction) = measure_tag(inflfn)
 Base.string(resamplefn::ResampleFunction) = method_tag(resamplefn)
 Base.string(trendfn::TrendFunction) = method_tag(trendfn)
-# Base.string(paramfn::Any) = nameof(paramfn)
-# Base.string(paramfn::InflationParameter) = method_tag(paramfn)
 
 # Método para mostrar información de la configuración en el REPL
 function Base.show(io::IO, config::AbstractConfig)

--- a/src/InflationEvalTools/src/config/SimConfig.jl
+++ b/src/InflationEvalTools/src/config/SimConfig.jl
@@ -8,7 +8,7 @@ general, una función de inflación [`InflationFunction`](@ref), una función de
 remuestreo [`ResampleFunction`](@ref) y una función de Tendencia
 [`TrendFunction`](@ref). Contiene el esquema general de la simulación.
 """
-abstract type AbstractConfig{F <: InflationFunction, R <:ResampleFunction, T <:TrendFunction} end
+abstract type AbstractConfig{F <: InflationFunction, R <:ResampleFunction, T <:TrendFunction, P<:InflationParameter} end
 
 """
     SimConfig{F, R, T} <:AbstractConfig{F, R, T}

--- a/src/InflationEvalTools/src/param/InflationParameter.jl
+++ b/src/InflationEvalTools/src/param/InflationParameter.jl
@@ -41,6 +41,7 @@ function Base.show(io::IO, param::AbstractInflationParameter)
     println(io, "|─> TrendFunction     : " * method_name(param.trendfn) )
 end
 
+method_tag(param::InflationParameter) = string("InflParam: [",nameof(param.inflfn),", ",nameof(param.resamplefn),", ",nameof(param.trendfn),"]")
 
 """
     DEFAULT_RESAMPLE_FN
@@ -71,7 +72,6 @@ ParamTotalCPIRebase() =
 # Función para obtener el parámetro con otra función de remuestreo y otra función de tendencia.
 ParamTotalCPIRebase(resamplefn::ResampleFunction, trendfn::TrendFunction) = 
     InflationParameter(InflationTotalRebaseCPI(60), resamplefn, trendfn)
-
 
 """
     ParamTotalCPI()

--- a/src/InflationEvalTools/src/simulate/simutils.jl
+++ b/src/InflationEvalTools/src/simulate/simutils.jl
@@ -55,11 +55,11 @@ Float32[5.035937; 5.7404637; … ; 8.130074; 7.985401])
 ```
 """
 function evalsim(data_eval::CountryStructure, config::SimConfig; 
-    param_constructor_fn=ParamTotalCPIRebase, 
     rndseed = 0)
   
     # Obtener la trayectoria paramétrica de inflación 
-    param = param_constructor_fn(config.resamplefn, config.trendfn)
+    param = InflationParameter(config.paramfn, config.resamplefn, config.trendfn)
+    # param = param_constructor_fn(config.resamplefn, config.trendfn)
     tray_infl_pob = param(data_eval)
 
     @info "Evaluación de medida de inflación" medida=measure_name(config.inflfn) remuestreo=method_name(config.resamplefn) tendencia=method_name(config.trendfn) simulaciones=config.nsim 

--- a/src/InflationEvalTools/src/simulate/simutils.jl
+++ b/src/InflationEvalTools/src/simulate/simutils.jl
@@ -62,7 +62,7 @@ function evalsim(data_eval::CountryStructure, config::SimConfig;
     # param = param_constructor_fn(config.resamplefn, config.trendfn)
     tray_infl_pob = param(data_eval)
 
-    @info "Evaluación de medida de inflación" medida=measure_name(config.inflfn) remuestreo=method_name(config.resamplefn) tendencia=method_name(config.trendfn) simulaciones=config.nsim 
+    @info "Evaluación de medida de inflación" medida=measure_name(config.inflfn) remuestreo=method_name(config.resamplefn) tendencia=method_name(config.trendfn) evaluación=measure_name(config.paramfn) simulaciones=config.nsim 
 
     # Generar las trayectorias de inflación de simulación 
     tray_infl = pargentrayinfl(config.inflfn, # función de inflación
@@ -132,12 +132,10 @@ Dict{Symbol, Any} with 11 entries:
 ```
 """
 function makesim(data, config::AbstractConfig; 
-    param_constructor_fn=ParamTotalCPIRebase, 
-    rndseed = rndseed)
+    rndseed = 0)
         
      # Ejecutar la simulación y obtener los resultados 
     metrics, tray_infl = evalsim(data, config; 
-        param_constructor_fn = param_constructor_fn, 
         rndseed = rndseed)
 
     # Agregar resultados a diccionario 
@@ -209,15 +207,13 @@ julia> df = collect_results(savepath)
 """
 function run_batch(data, dict_list_params, savepath; 
     savetrajectories = true, 
-    param_constructor_fn = ParamTotalCPIRebase, 
     rndseed = 0)
 
     # Ejecutar lote de simulaciones 
     for (i, dict_params) in enumerate(dict_list_params)
         @info "Ejecutando simulación $i de $(length(dict_list_params))..."
         config = dict_config(dict_params) 
-        results, tray_infl = makesim(data, config; 
-            param_constructor_fn=param_constructor_fn, 
+        results, tray_infl = makesim(data, config;
             rndseed = rndseed)
         print("\n\n\n")
 
@@ -269,9 +265,9 @@ Función para convertir diccionario a `AbstractConfig`.
 """
 function dict_config(params::Dict)
     # configD = SimConfig(dict_prueba[:inflfn], dict_prueba[:resamplefn], dict_prueba[:trendfn], dict_prueba[:nsim])
-    if length(params) == 4
-        config = SimConfig(params[:inflfn], params[:resamplefn], params[:trendfn], params[:nsim])
+    if length(params) == 5
+        config = SimConfig(params[:inflfn], params[:resamplefn], params[:trendfn], params[:paramfn], params[:nsim])
     else
-        config = CrossEvalConfig(params[:inflfn], params[:resamplefn], params[:trendfn], params[:nsim], params[:train_date], params[:eval_size])        
+        config = CrossEvalConfig(params[:inflfn], params[:resamplefn], params[:trendfn], params[:paramfn], params[:nsim], params[:train_date], params[:eval_size])        
     end
 end

--- a/src/InflationFunctions/src/InflationTotalRebaseCPI.jl
+++ b/src/InflationFunctions/src/InflationTotalRebaseCPI.jl
@@ -15,7 +15,7 @@ InflationTotalRebaseCPI(period::Int) = InflationTotalRebaseCPI(period, 0)
 # Nombre de la medida
 measure_name(::InflationTotalRebaseCPI) = "Variación interanual IPC con cambios de base sintéticos"
 # Etiqueta 
-measure_tag(inflfn::InflationTotalRebaseCPI) = "TotalRebaseCPI-" * string(period)
+measure_tag(inflfn::InflationTotalRebaseCPI) = "TotalRebaseCPI-" * string(inflfn.period)
 
 # Parámetros
 params(totalrebasefn::InflationTotalRebaseCPI) = (totalrebasefn.period, )

--- a/src/InflationFunctions/src/InflationTotalRebaseCPI.jl
+++ b/src/InflationFunctions/src/InflationTotalRebaseCPI.jl
@@ -13,9 +13,12 @@ end
 InflationTotalRebaseCPI(period::Int) = InflationTotalRebaseCPI(period, 0)
 
 # Nombre de la medida
-measure_name(::InflationTotalRebaseCPI) = "Variación interanual IPC con cambios de base sintéticos"
+measure_name(inflfn::InflationTotalRebaseCPI) = 
+    "Variación interanual IPC con cambios de base sintéticos ($(inflfn.period), $(inflfn.maxchanges))"
+
 # Etiqueta 
-measure_tag(inflfn::InflationTotalRebaseCPI) = "TotalRebaseCPI-" * string(inflfn.period)
+measure_tag(inflfn::InflationTotalRebaseCPI) = 
+    "TotalRebaseCPI-($(inflfn.period),$(inflfn.maxchanges))"
 
 # Parámetros
 params(totalrebasefn::InflationTotalRebaseCPI) = (totalrebasefn.period, )


### PR DESCRIPTION
Se propone agregar a la configuración de simulación la función de inflación para aplicar a los datos paramétricos.